### PR TITLE
feature/exit safety

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -40,8 +40,8 @@ push-local: build
     docker push rgpeach10/shell:$(git symbolic-ref --short HEAD | sed 's/\//__/g')
 
 stow: 
-    stow -t $HOME -d ./home
+    stow -t $HOME home
 
 stow-hard:
-    stow -t $HOME -d ./home --adopt
+    stow -t $HOME --adopt home
     git reset --hard

--- a/Justfile
+++ b/Justfile
@@ -38,3 +38,10 @@ push-local: build
     echo $(git symbolic-ref --short HEAD | sed 's/\//__/g')
     docker tag rgpeach10/shell:local rgpeach10/shell:$(git symbolic-ref --short HEAD | sed 's/\//__/g')
     docker push rgpeach10/shell:$(git symbolic-ref --short HEAD | sed 's/\//__/g')
+
+stow: 
+    stow -t $HOME -d ./home
+
+stow-hard:
+    stow -t $HOME -d ./home --adopt
+    git reset --hard

--- a/README.md
+++ b/README.md
@@ -64,29 +64,23 @@ This will allow you to safely edit your config from within your docker container
 
 # If you want to use this zshrc file and other configs on your local!
 
-Create a `.zshrc.private.local` file in your home directory.
+Create a `.zshrc.private.local` file in your home directory. Anything that you want to source specific to your os or local machine should go in here.
 
-It may source your `.zshrc.private` file, if you'd like everything in it (which is usually applied to docker containers) to be applied to your local shell as well.
+Creating this file will prevent the sourcing of the `.zshrc.private` file in this repo.
 
-Just add the following to your `.zshrc.private.local` file:
+If you ALSO want to source the `.zshrc.private` file in this repo, you can do so by adding the following to your `.zshrc.private.local` file:
 
 ```bash
-export ZSH_PRIVATE_LOC=$HOME/.zshrc.private.local
+source /path/to/.zshrc.private
+```
+
+Also please move the `shell `directory itself as a subdirectory of `$HOME`, or else set:
+
+```bash
 export SHELL_MNT_DIR=$HOME/shell # or wherever you cloned this repo
-export MNT=$HOME
 ```
 
-If you have nothing Docker Container specific (and usually even if you do), this can just say:
-
-```bash
-source $HOME/.zshrc.private
-```
-
-A reason you might put something in here that's NOT in your `.zshrc.private` is if you have an os-specific command that you would run privately but WOULD NOT want to run in the container.
-
-In general, `if [[ $IS_DOCKER ]]` this repo will assume you are running in the container.
-
-IF YOU WANT TO GET RID OF YOUR LOCAL CONFIGS IN FAVOR OF THOSE IN THIS REPO
+IF YOU WANT TO GET RID OF YOUR LOCAL CONFIGS IN FAVOR OF THOSE IN THIS REPO, go into the `shell` directory and run:
 
 ```bash
 just stow-hard

--- a/README.md
+++ b/README.md
@@ -64,15 +64,17 @@ This will allow you to safely edit your config from within your docker container
 
 # If you want to use this zshrc file and other configs on your local!
 
-Just make a `.zprofile` that looks like this
+Create a `.zshrc.private.local` file in your home directory.
+
+It may source your `.zshrc.private` file, if you'd like everything in it (which is usually applied to docker containers) to be applied to your local shell as well.
+
+Just add the following to your `.zshrc.private.local` file:
 
 ```bash
 export ZSH_PRIVATE_LOC=$HOME/.zshrc.private.local
 export SHELL_MNT_DIR=$HOME/shell # or wherever you cloned this repo
 export MNT=$HOME
 ```
-
-And make a `$HOME/.zshrc.private.local` (like your `$HOME/.zshrc.private` but will only be sourced by your local copy of the zshrc file) 
 
 If you have nothing Docker Container specific (and usually even if you do), this can just say:
 
@@ -84,13 +86,10 @@ A reason you might put something in here that's NOT in your `.zshrc.private` is 
 
 In general, `if [[ $IS_DOCKER ]]` this repo will assume you are running in the container.
 
-Now, `stow home`
-
 IF YOU WANT TO GET RID OF YOUR LOCAL CONFIGS IN FAVOR OF THOSE IN THIS REPO
 
 ```bash
-stow --adopt home
-git reset HEAD --hard
+just stow-hard
 ```
 
 # Running from the Repo

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Just make a `.zprofile` that looks like this
 
 ```bash
 export ZSH_PRIVATE_LOC=$HOME/.zshrc.private.local
+export SHELL_MNT_DIR=$HOME/shell # or wherever you cloned this repo
 export MNT=$HOME
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ This will allow you to safely edit your config from within your docker container
 
 # If you want to use this zshrc file and other configs on your local!
 
-**I MAKE NO GUARENTEES, I ONLY TEST THIS ON MY OWN MACHINES!!! DO NOT TRY AT HOME. COULD CAUSE DATA LOSS.**
-
 Just make a `.zprofile` that looks like this
 
 ```bash
@@ -73,11 +71,26 @@ export ZSH_PRIVATE_LOC=$HOME/.zshrc.private.local
 export MNT=$HOME
 ```
 
-And make a `$HOME/.zshrc.private.local` (like your `$HOME/.zshrc.private` but will only be sourced by your local copy of the zshrc file)
+And make a `$HOME/.zshrc.private.local` (like your `$HOME/.zshrc.private` but will only be sourced by your local copy of the zshrc file) 
 
-In general, `if [[ "$MNT" == "$HOME" ]]` this repo will assume you have copied it to a local machine.
+If you have nothing Docker Container specific (and usually even if you do), this can just say:
 
-**I MAKE NO GUARENTEES, I ONLY TEST THIS ON MY OWN MACHINES!!! DO NOT TRY AT HOME. COULD CAUSE DATA LOSS.**
+```bash
+source $HOME/.zshrc.private
+```
+
+A reason you might put something in here that's NOT in your `.zshrc.private` is if you have an os-specific command that you would run privately but WOULD NOT want to run in the container.
+
+In general, `if [[ $IS_DOCKER ]]` this repo will assume you are running in the container.
+
+Now, `stow home`
+
+IF YOU WANT TO GET RID OF YOUR LOCAL CONFIGS IN FAVOR OF THOSE IN THIS REPO
+
+```bash
+stow --adopt home
+git reset HEAD --hard
+```
 
 # Running from the Repo
 

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -25,3 +25,6 @@
 
 [push]
     autoSetupRemote=true
+[user]
+	email = rgpeach10@gmail.com
+	name = Ryan Peach

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -17,6 +17,33 @@ fi
 # If you come from bash you might have to change your $PATH.
 export PATH=$HOME/bin:/usr/local/bin:$HOME/.local/bin:$PATH:/opt/homebrew/bin
 
+# Load private info location
+if [ -z "$ZSH_PRIVATE_LOC" ]; then
+    ZSH_PRIVATE_LOC=$MNT/.zshrc.private
+fi
+
+# If it does not exist, inform them
+if [ ! -f "$ZSH_PRIVATE_LOC" ]; then
+    echo "No .zshrc.private found at '$ZSH_PRIVATE_LOC'"
+    echo "You should create this to add secret information to your session"
+    echo "Usually you put it in your home directory or in the directory"
+    echo "mounted to this containers $MNT. However, wherever you put it, you can"
+    echo "always override the location by overriding the ZSH_PRIVATE_LOC env variable"
+else
+    source $ZSH_PRIVATE_LOC
+fi
+
+# This is our github copilot hosts file
+# make a symbolic link to $MNT
+if [[ $IS_DOCKER ]]; then
+    mkdir -p ~/.config/github-copilot
+    if ! [ -f "$MNT/.config/github-copilot/hosts.json" ]; then
+        echo "No hosts.json found in $MNT/.config/github-copilot/hosts.json"
+    else
+        ln -s $MNT/.config/github-copilot/hosts.json ~/.config/github-copilot/hosts.json
+    fi
+fi
+
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
@@ -266,31 +293,6 @@ fi
 # Neofetch
 if [ -z "$DEBUG" ]; then
     clear
-fi
-
-# This is our github copilot hosts file
-# make a symbolic link to $MNT
-if [[ $IS_DOCKER ]]; then
-    mkdir -p ~/.config/github-copilot
-    if ! [ -f "$MNT/.config/github-copilot/hosts.json" ]; then
-        echo "No hosts.json found in $MNT/.config/github-copilot/hosts.json"
-    else
-        ln -s $MNT/.config/github-copilot/hosts.json ~/.config/github-copilot/hosts.json
-    fi
-fi
-
-# Load private info location
-if [ -z "$ZSH_PRIVATE_LOC" ]; then
-    ZSH_PRIVATE_LOC=$MNT/.zshrc.private
-fi
-
-# If it does not exist, inform them
-if [ ! -f "$ZSH_PRIVATE_LOC" ]; then
-    echo "No .zshrc.private found at '$ZSH_PRIVATE_LOC'"
-    echo "You should create this to add secret information to your session"
-    echo "Usually you put it in your home directory or in the directory"
-    echo "mounted to this containers $MNT. However, wherever you put it, you can"
-    echo "always override the location by overriding the ZSH_PRIVATE_LOC env variable"
 else
-    source $ZSH_PRIVATE_LOC
+    neofetch
 fi

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -1,12 +1,11 @@
-# clear at the beginning
-if [ -z "$DEBUG" ]; then
-    clear
-fi
-
 # This where you typically mount your home directory
 # but it can be overwritten in your .zprofile
 if [ -z "$MNT" ]; then
-    export MNT=$HOME/mnt
+    export MNT=$HOME
+fi
+
+if [ -z "$SHELL_MNT_DIR" ]; then
+    SHELL_MNT_DIR="$MNT/shell"
 fi
 
 # If $MNT is not $HOME, then we are running in docker
@@ -19,18 +18,20 @@ export PATH=$HOME/bin:/usr/local/bin:$HOME/.local/bin:$PATH:/opt/homebrew/bin
 
 # Load private info location
 if [ -z "$ZSH_PRIVATE_LOC" ]; then
-    ZSH_PRIVATE_LOC=$MNT/.zshrc.private
+    ZSH_PRIVATE_LOC=$MNT
 fi
 
-# If it does not exist, inform them
-if [ ! -f "$ZSH_PRIVATE_LOC" ]; then
-    echo "No .zshrc.private found at '$ZSH_PRIVATE_LOC'"
+# Load private info location
+if [ -f "$ZSH_PRIVATE_LOC/.zshrc.private.local" ]; then
+    source $ZSH_PRIVATE_LOC/.zshrc.private.local
+elif [ -f "$ZSH_PRIVATE_LOC/.zshrc.private" ]; then
+    source $ZSH_PRIVATE_LOC/.zshrc.private
+else
+    echo "No .zshrc.private or .zshrc.private.local found at '$ZSH_PRIVATE_LOC'"
     echo "You should create this to add secret information to your session"
     echo "Usually you put it in your home directory or in the directory"
     echo "mounted to this containers $MNT. However, wherever you put it, you can"
     echo "always override the location by overriding the ZSH_PRIVATE_LOC env variable"
-else
-    source $ZSH_PRIVATE_LOC
 fi
 
 # This is our github copilot hosts file
@@ -227,9 +228,7 @@ build-deps () {
 # We need to make sure we don't loose our changes to our dotfiles when we close our docker container
 # We also need to support running more than one docker container at a time
 # stow-shell() {
-#     if [ -z "$SHELL_MNT_DIR" ]; then
-#         SHELL_MNT_DIR="$MNT/shell"
-#     fi
+
 #     if [ -d "$SHELL_MNT_DIR" ]; then
 #         cd $SHELL_MNT_DIR
 #         if [ -z "$(git status --porcelain)" ]; then
@@ -291,8 +290,4 @@ fi
 ## ==============================================
 
 # Neofetch
-if [ -z "$DEBUG" ]; then
-    clear
-else
-    neofetch
-fi
+neofetch


### PR DESCRIPTION
- **This should prevent exits when shell git is not porcelean**
- **Since the dockerfile uses the last HEAD, error if its not clean**
- **Since the dockerfile uses the last HEAD, error if its not clean**
- **Experimenting with this porcelean exit**
- **Ignore untracked files**
- **We didn't need to alias exit bc of the trap**
- **Custom commands for mason install and lsp install**
- **Get rid of tmp copy**
- **no copilot chat for now**
- **TODO: unexpectedly started multiple copilot server**
- **Got rid of rm**
- **lspconfig command was wrong**
- **Just get rid of auto downloading mason and lsp. TODO**
- **No parser for markdown. TODO**
- **Fixed git diff in docker**
- **Why are there changes**
- **Add global stuff to the local gitignore**
- **Maybe another tsupdate will help**
- **Maybe another tsupdate will help**
- **Maybe another tsupdate will help**
- **Completely pointless**
- **lua format**
- **Better readme for local**
- **Mention shell_mnt_dir**
- **Improved documentation**
- **Better documentation**
